### PR TITLE
Candy.View.Observer.Message: Check that the message has a body before showing it.

### DIFF
--- a/src/view/observer.js
+++ b/src/view/observer.js
@@ -171,6 +171,7 @@ Candy.View.Observer = (function(self, $) {
 				if(args.message.type === 'chat' && !Candy.View.Pane.Chat.rooms[args.roomJid]) {
 					Candy.View.Pane.PrivateRoom.open(args.roomJid, args.message.name, false, args.message.isNoConferenceRoomJid);
 				}
+				if(args.message.body && args.message.body.length > 0)
 				Candy.View.Pane.Message.show(args.roomJid, args.message.name, args.message.body, args.timestamp);
 			}
 		}


### PR DESCRIPTION
Chat state notifications are apparently shown as empty lines. This should fix that.
