### PR TITLE
Allow changing nick even when provided user crendetials

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -161,7 +161,11 @@ Candy.Core = (function(self, Strophe, $) {
 		if(jidOrHost && password) {
 			// authentication
 			_connection.connect(_getEscapedJidFromJid(jidOrHost) + '/' + Candy.about.name, password, Candy.Core.Event.Strophe.Connect);
-			_user = new self.ChatUser(jidOrHost, Strophe.getNodeFromJid(jidOrHost));
+            if (nick) {
+			  _user = new self.ChatUser(jidOrHost, nick);
+            } else {
+			  _user = new self.ChatUser(jidOrHost, Strophe.getNodeFromJid(jidOrHost));
+            }
 		} else if(jidOrHost && nick) {
 			// anonymous connect
 			_connection.connect(_getEscapedJidFromJid(jidOrHost) + '/' + Candy.about.name, null, Candy.Core.Event.Strophe.Connect);


### PR DESCRIPTION
I would like to login under on defined user to allow semi-anonymous access. I'll differentiate among users though setting their nicknames. This simple change allows passing nick even when complete credentials are provided.
