### PR TITLE
Allow to pass room password via autojoin

### DIFF
--- a/src/core/action.js
+++ b/src/core/action.js
@@ -60,6 +60,7 @@ Candy.Core.Action = (function(self, Strophe, $) {
 		 * When Candy.Core.getOptions().autojoin is true, request autojoin bookmarks (OpenFire)
 		 *
 		 * Otherwise, if Candy.Core.getOptions().autojoin is an array, join each channel specified.
+		 * Channel can be in jid:password format to pass room password if needed.
 		 */
 		Autojoin: function() {
 			// Request bookmarks
@@ -68,7 +69,7 @@ Candy.Core.Action = (function(self, Strophe, $) {
 			// Join defined rooms
 			} else if($.isArray(Candy.Core.getOptions().autojoin)) {
 				$.each(Candy.Core.getOptions().autojoin, function() {
-					self.Jabber.Room.Join(this.valueOf());
+					self.Jabber.Room.Join.apply(null, this.valueOf().split(':',2));
 				});
 			}
 		},


### PR DESCRIPTION
My use case is that I'll use
- one user for all users coming to service
- autojoin to join the desired chat room

So I want to have some additional level of protection, when the user credentials are virtually shared. So every room will be protected with different password. This commit adds support for specifying password when passing array to autojoin in format:

  jid:password

for example:

   test@conference.im.example.org:password

Following the common URL schema, the format should be e.g. test:password@conference.im.example.org ; but the one proposed seemed a bit cleaner to the user. What do you think?
