### PR TITLE
Use a protocol-relative URL to support SSL out of the box.

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -6,7 +6,7 @@
 	<link rel="shortcut icon" href="../res/img/favicon.png" type="image/gif" />
 	<link rel="stylesheet" type="text/css" href="../res/default.css" />
 	
-	<script type="text/javascript" src="http://ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"></script>
+	<script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.7.0/jquery.min.js"></script>
 	<script type="text/javascript" src="../libs/libs.min.js"></script>
 	<script type="text/javascript" src="../candy.min.js"></script>
 	<script type="text/javascript">


### PR DESCRIPTION
I'm planning to run Candy under SSL, and I imagine some folks might want to as well. With that in mind, why not pull in jQuery using a protocol-relative URL so that this just works out of the box?
