### PR TITLE
Fixes #135 : iso8601toDate is not adding the timezoneOffset to the calculated time

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -261,7 +261,10 @@ Candy.Util = (function(self, $){
 						minutesOffset = -minutesOffset;
 					}
 				}
-				return new Date(+struct[1], +struct[2] - 1, +struct[3], +struct[4], +struct[5] + minutesOffset, +struct[6], struct[7] ? +struct[7].substr(0, 3) : 0);
+				var constructedDate = new Date(+struct[1], +struct[2] - 1, +struct[3], +struct[4], +struct[5] + minutesOffset, +struct[6], struct[7] ? +struct[7].substr(0, 3) : 0);
+                		var timezoneOffsetInMinutes = new Date().getTimezoneOffset();
+
+                		return new Date(constructedDate.getTime() - timezoneOffsetInMinutes * 60 * 1000);
 			} else {
 				// XEP-0091 date
 				timestamp = Date.parse(date.replace(/^(\d{4})(\d{2})(\d{2})/, '$1-$2-$3') + 'Z');


### PR DESCRIPTION
Fixed the issue by adding the timezoneoffset calculated from browser to the Date object constructed in the iso8601toDate method.
