### PR TITLE
use bareJID in direct message

### DIFF
--- a/src/view/observer.js
+++ b/src/view/observer.js
@@ -212,6 +212,9 @@ Candy.View.Observer = (function(self, $) {
 				Candy.View.Pane.Chat.infoMessage(args.roomJid, args.message.body);
 			} else {
 				// Initialize room if it's a message for a new private user chat
+				if(args.message.isNoConferenceRoomJid){
+					args.roomJid = Strophe.getBareJidFromJid(args.roomJid)
+				}
 				if(args.message.type === 'chat' && !Candy.View.Pane.Chat.rooms[args.roomJid]) {
 					Candy.View.Pane.PrivateRoom.open(args.roomJid, args.message.name, false, args.message.isNoConferenceRoomJid);
 				}


### PR DESCRIPTION
when received a direct message, it works normally.
and if then received a message from same user but different resource, candy showed another room.
