### PR TITLE
Fixed: "Candy.Core.getRoom(roomJid).getUser() is null" when you destroy the room

### DIFF
--- a/src/core/action.js
+++ b/src/core/action.js
@@ -160,7 +160,9 @@ Candy.Core.Action = (function(self, Strophe, $) {
 			 *   (String) roomJid - Room to leave
 			 */
 			Leave: function(roomJid) {
-				Candy.Core.getConnection().muc.leave(roomJid, Candy.Core.getRoom(roomJid).getUser().getNick(), function() {});
+				if(Candy.Core.getRoom(roomJid).getUser()){
+					Candy.Core.getConnection().muc.leave(roomJid, Candy.Core.getRoom(roomJid).getUser().getNick(), function() {});
+				}
 			},
 
 			/** Function: Disco


### PR DESCRIPTION
I have created a method to destroy the entire room, and with that, I found an error that the User its null, affecting the "Leave" method.

To reproduce:
- Create a room
- Send the stanza to destroy the room

Expected:
- Candy gets disconnected

Actual:
- An error is shown in the console: "Candy.Core.getRoom(roomJid).getUser() is null"
