### PR TITLE
Remove all bottom margin from the message form

### DIFF
--- a/res/default.css
+++ b/res/default.css
@@ -373,6 +373,7 @@ ul {
 	left: 0;
 	right: 0;
 	margin-right: 320px;
+	margin-bottom: 0;
 	padding: 0;
 }
 


### PR DESCRIPTION
On Chrome (v. 27.0.1453.116 on Mac OS X 10.8.4, at least), the default user agent stylesheet adds a `1em` bottom margin to forms. This results in an ugly bump up of the message form. Setting the value to 0 explicitly in the default CSS prevents this.

I noticed this while integrating Candy.js into OpenEdX, and @caesar2164 discovered the fix. Here are screenshots so you can see what I was seeing.

![screen shot 2013-06-19 at 4 19 21 pm](https://f.cloud.github.com/assets/1433806/678516/22437a6a-d939-11e2-978e-3e3e53698185.png)
![screen shot 2013-06-19 at 4 19 24 pm](https://f.cloud.github.com/assets/1433806/678517/253a39b6-d939-11e2-967a-479118fad28b.png)
![screen shot 2013-06-19 at 4 20 48 pm](https://f.cloud.github.com/assets/1433806/678518/289187b8-d939-11e2-8f8c-6801203bcd4e.png)
