### PR TITLE
Adds callback handler for Message events. 

### DIFF
--- a/candy.bundle.js
+++ b/candy.bundle.js
@@ -2357,6 +2357,16 @@ Candy.View.Event = (function(self, $) {
 	 * Message-related events
 	 */
 	self.Message = {
+		__callbacks: [],
+		/**
+		 * Function addCallback
+		 * @param fn
+		 * Allows multiple plugins to operate on a specific event
+		 * i.e. Candy.View.Event.Message.addCallback(handleOnShow)
+		 */
+		addCallback: function(fn) {
+			this.__callbacks.push(fn);
+		},
 		/** Function: beforeShow
 		 * Called before a new message will be shown.
 		 *
@@ -2377,6 +2387,9 @@ Candy.View.Event = (function(self, $) {
 		 *   (Object) args - {roomJid, element, nick, message}
 		 */
 		onShow: function(args) {
+			for (f in this.__callbacks) {
+				this.__callbacks[f].call(this, args);
+			}
 			return;
 		},
 		


### PR DESCRIPTION
Several plugins override Candy.View.Event.Message.onShow which is bad practice, primarily because only the last initiated plugin will run. This code introduces addCallback(fn) which can and should be used instead of assigning onShow.

Thank you.
