### PR TITLE
Random seed in resource

### DIFF
--- a/candy.bundle.js
+++ b/candy.bundle.js
@@ -238,7 +238,7 @@ Candy.Core = (function(self, Strophe, $) {
 
 		if(jidOrHost && password) {
 			// authentication
-			_connection.connect(_getEscapedJidFromJid(jidOrHost) + '/' + Candy.about.name, password, Candy.Core.Event.Strophe.Connect);
+			_connection.connect(_getEscapedJidFromJid(jidOrHost) + '/' + Candy.about.name + '-' + Math.random().toString(36).slice(2), password, Candy.Core.Event.Strophe.Connect);
 			if (nick) {
 				_user = new self.ChatUser(jidOrHost, nick);
 			} else {
@@ -246,7 +246,7 @@ Candy.Core = (function(self, Strophe, $) {
 			}
 		} else if(jidOrHost && nick) {
 			// anonymous connect
-			_connection.connect(_getEscapedJidFromJid(jidOrHost) + '/' + Candy.about.name, null, Candy.Core.Event.Strophe.Connect);
+			_connection.connect(_getEscapedJidFromJid(jidOrHost) + '/' + Candy.about.name + '-' + Math.random().toString(36).slice(2), null, Candy.Core.Event.Strophe.Connect);
 			_user = new self.ChatUser(null, nick); // set jid to null because we'll later receive it
 		} else if(jidOrHost) {
 			Candy.Core.Event.Login(jidOrHost);


### PR DESCRIPTION
Extending resource with some random characters+digits may be helpful in case when only a single account (JID) is used for connecting to a conference room. In my case, Prosody.im kicked the old user leaving alone the new user in the room. It's also possible to change it in the server configuration but the convention is that each connection should have its unique resource.
