### PR TITLE
Hack CSS to improve readability on a mobile device.

### DIFF
--- a/example/index.html
+++ b/example/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
 	<meta charset="utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
+	<meta name="viewport" content="width=device-width, initial-scale=1, maximum-scale=1" />
 	<title>Candy - Chats are not dead yet</title>
 	<link rel="shortcut icon" href="../res/img/favicon.png" type="image/gif" />
 	<link rel="stylesheet" type="text/css" href="../res/default.css" />

--- a/res/default.css
+++ b/res/default.css
@@ -674,29 +674,31 @@ ul {
 	.message-form-wrapper {
 		margin-right: 0;
 		border-top: 0;
-		height: 5%;
+		height: 3em;
 	}
 	.message-form {
-		margin-right: 0;
-		height: 5%;
+		margin-right: 3.5em;
+		height: 3em;
 	}
 	.message-form input {
 		padding: 0;
-		font-size: auto;
+		height: 3em;
+		font-size: 100%;
 	}
 	.message-form input.submit {
 		margin: 0;
 		padding: 0;
-		height: 5%;
-		line-height: auto;
+		height: 3em;
+		font-size: 100%;
+		line-height: 100%;
 	}
 	.message-pane-wrapper {
-		margin: auto;
-		width: 100%;
-		height: 90%;
+		margin: 1.9em 0 3em 0;
+		font-size: 1em;
 	}
 	.message-pane li>div {
 		padding: 0;
+		line-height: 1.2em;
 	}
 	.message-pane .label {
 		float: none;
@@ -711,7 +713,7 @@ ul {
 		display: none;
 		z-index: 1;
 		position: fixed;
-		margin: 10% 0;
+		margin: 1.9em 0 3em 0;
 		width: 50%;
 		border-top: 0.1em solid black;
 		box-shadow: none;
@@ -734,11 +736,11 @@ ul {
 	}
 	#chat-tabs {
 		margin: 0;
-		height: 5%;
+		height: 1.9em;
 	}
 	#chat-tabs a {
 		padding: 0.1em 2em 0.1em 0.3em;
-		height: auto;
+		height: 1.9em;
 	}
 	#chat-toolbar {
 		position: absolute;


### PR DESCRIPTION
- example/index.html: Add viewport information to set width to
  device-width and initial-scale to 1.
- res/default.css: If width is below 480px:
  - hide roster-pane and toolbar,
  - use full width for message-pane and message-form,
  - put the number of users icon on top right,
  - clicking on this icon make the roster-pane appear.
