### PR TITLE
removed excessive escaping

### DIFF
--- a/src/core/action.js
+++ b/src/core/action.js
@@ -253,7 +253,6 @@ Candy.Core.Action = (function(self, Strophe, $) {
 			 */
 			Leave: function(roomJid) {
 				var user = Candy.Core.getRoom(roomJid).getUser();
-				roomJid = Candy.Util.escapeJid(roomJid);
 				if (user) {
 					Candy.Core.getConnection().muc.leave(roomJid, user.getNick(), function() {});
 				}


### PR DESCRIPTION
No need to escape room-jid, while leaving, as Strophe.muc.leave() does escaping on its own

see: https://github.com/strophe/strophejs-plugins/blob/5e65dda2f0b406f91afcd4ed2a9124e9a7ad626e/muc/strophe.muc.js#L143 and https://github.com/strophe/strophejs-plugins/blob/5e65dda2f0b406f91afcd4ed2a9124e9a7ad626e/muc/strophe.muc.js#L580
