### PR TITLE
Log strophe messages to console when debug mode is on

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -122,6 +122,32 @@ Candy.Core = (function(self, Strophe, $) {
 					};
 				}
 			}
+			Strophe.log = function (level, message) {
+				var level_name, console_level;
+				switch (level) {
+					case Strophe.LogLevel.DEBUG:
+						level_name = 'DEBUG';
+						console_level = 'log';
+						break;
+					case Strophe.LogLevel.INFO:
+						level_name = 'INFO';
+						console_level = 'info';
+						break;
+					case Strophe.LogLevel.WARN:
+						level_name = 'WARN';
+						console_level = 'info';
+						break;
+					case Strophe.LogLevel.ERROR:
+						level_name = 'ERROR';
+						console_level = 'error';
+						break;
+					case Strophe.LogLevel.FATAL:
+						level_name = 'FATAL';
+						console_level = 'error';
+						break;
+				}
+				console[console_level]('[Strophe][' + level_name + ']: ' + message);
+			};
 			self.log('[Init] Debugging enabled');
 		}
 


### PR DESCRIPTION
Log errors at appropriate level. This mostly addresses https://github.com/candy-chat/candy/issues/248#issuecomment-50351725, with the exception that the original exception's stack trace is lost. This is [Strophe's fault](https://github.com/strophe/strophejs/blob/master/src/core.js#L2219-L2222) and we can't fix it ourselves.

See #248.
