### PR TITLE
Merges the Candy dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ candy.bundle.*
 candy.min.*
 libs.bundle.*
 libs.min.*
+.vagrant

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,8 +21,7 @@ A few hopefully helpful hints to contributing to Candy
 #### Using vagrant
 1. [Fork](https://help.github.com/articles/fork-a-repo) Candy
 2. [Install Vagrant](http://vagrantup.com/)
-3. Follow instructions [for Candy Vagrant](https://github.com/candy-chat/vagrant)
-4. Change the remote in the `candy` and `candy-plugins` repos: `git remote set-url origin git://github.com/YOURNAME/candy` (or candy-plugins)
+3. Run `vagrant up`.
 5. Create a branch based on the `dev` branch (`git checkout -B my-awesome-feature`)
 6. Run `grunt watch` to automatically run jshint (syntax checker) and the build of `candy.bundle.js` and `candy.min.js` while developing.
 7. Make your changes, fix eventual *jshint* errors & push them back to your fork

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,19 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.network :forwarded_port, guest: 80, host: 8080
+  config.vm.network :forwarded_port, guest: 5280, host: 5280
+  config.vm.network :forwarded_port, guest: 4444, host: 4444
+  config.vm.network :private_network, ip: '192.168.88.4'
+
+  config.vm.provision :shell, :path => "devbox/provisioning.sh"
+
+  config.vm.provider "virtualbox" do |v|
+    v.name = "candy"
+  end
+end

--- a/devbox/index.html
+++ b/devbox/index.html
@@ -1,0 +1,50 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Candy - Chats are not dead yet</title>
+  <link rel="shortcut icon" href="candy/res/img/favicon.png" type="image/gif" />
+  <link rel="stylesheet" type="text/css" href="candy/res/default.css" />
+
+  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.10.2/jquery.min.js"></script>
+  <script type="text/javascript" src="candy/libs/libs.min.js"></script>
+  <script type="text/javascript" src="candy/candy.min.js"></script>
+  <script type="text/javascript">
+    $(document).ready(function() {
+      //Candy.init('/http-bind/', { // uncomment & comment next line if you'd like to use BOSH
+      Candy.init('ws://localhost:5280/xmpp-websocket/', {
+        core: {
+          // only set this to true if developing / debugging errors
+          debug: true,
+          // autojoin is a *required* parameter if you don't have a plugin (e.g. roomPanel) for it
+          //   true
+          //     -> fetch info from server (NOTE: does only work with openfire server)
+          //   ['test@conference.example.com']
+          //     -> array of rooms to join after connecting
+          autojoin: ['test@conference.localhost']
+        },
+        view: { resources: 'candy/res/' }
+      });
+
+      Candy.Core.connect('localhost');
+
+      /**
+       * Thanks for trying Candy!
+       *
+       * If you need more information, please see here:
+       *   - Setup instructions & config params: http://candy-chat.github.io/candy/#setup
+       *   - FAQ & more: https://github.com/candy-chat/candy/wiki
+       *
+       * Mailinglist for questions:
+       *   - http://groups.google.com/group/candy-chat
+       *
+       * Github issues for bugs:
+       *   - https://github.com/candy-chat/candy/issues
+       */
+    });
+  </script>
+</head>
+<body>
+  <div id="candy"></div>
+</body>
+</html>

--- a/devbox/nginx-default.conf
+++ b/devbox/nginx-default.conf
@@ -1,0 +1,14 @@
+server {
+	root /usr/share/nginx/html;
+	index index.html;
+
+	charset utf-8;
+
+	server_name localhost;
+
+	location /http-bind/ {
+		proxy_pass  http://localhost:5280/http-bind/;
+		proxy_buffering off;
+		tcp_nodelay on;
+	}
+}

--- a/devbox/prosody.cfg.lua
+++ b/devbox/prosody.cfg.lua
@@ -1,0 +1,183 @@
+-- Prosody Example Configuration File
+--
+-- Information on configuring Prosody can be found on our
+-- website at http://prosody.im/doc/configure
+--
+-- Tip: You can check that the syntax of this file is correct
+-- when you have finished by running: luac -p prosody.cfg.lua
+-- If there are any errors, it will let you know what and where
+-- they are, otherwise it will keep quiet.
+--
+-- The only thing left to do is rename this file to remove the .dist ending, and fill in the
+-- blanks. Good luck, and happy Jabbering!
+
+
+---------- Server-wide settings ----------
+-- Settings in this section apply to the whole server and are the default settings
+-- for any virtual hosts
+
+-- This is a (by default, empty) list of accounts that are admins
+-- for the server. Note that you must create the accounts separately
+-- (see http://prosody.im/doc/creating_accounts for info)
+-- Example: admins = { "user1@example.com", "user2@example.net" }
+admins = { }
+
+-- Enable use of libevent for better performance under high load
+-- For more information see: http://prosody.im/doc/libevent
+use_libevent = true;
+
+-- This is the list of modules Prosody will load on startup.
+-- It looks for mod_modulename.lua in the plugins folder, so make sure that exists too.
+-- Documentation on modules can be found at: http://prosody.im/doc/modules
+modules_enabled = {
+
+	-- Generally required
+		"roster"; -- Allow users to have a roster. Recommended ;)
+		"saslauth"; -- Authentication for clients and servers. Recommended if you want to log in.
+		"tls"; -- Add support for secure TLS on c2s/s2s connections
+		"dialback"; -- s2s dialback support
+		"disco"; -- Service discovery
+
+	-- Not essential, but recommended
+		"private"; -- Private XML storage (for room bookmarks, etc.)
+		--"vcard"; -- Allow users to set vCards
+		"privacy"; -- Support privacy lists
+		--"compression"; -- Stream compression
+
+	-- Nice to have
+		--"legacyauth"; -- Legacy authentication. Only used by some old clients and bots.
+		"version"; -- Replies to server version requests
+		"uptime"; -- Report how long server has been running
+		"time"; -- Let others know the time here on this server
+		"ping"; -- Replies to XMPP pings with pongs
+		--"pep"; -- Enables users to publish their mood, activity, playing music and more
+		"register"; -- Allow users to register on this server using a client and change passwords
+		"adhoc"; -- Support for "ad-hoc commands" that can be executed with an XMPP client
+
+	-- Admin interfaces
+		"admin_adhoc"; -- Allows administration via an XMPP client that supports ad-hoc commands
+		--"admin_telnet"; -- Opens telnet console interface on localhost port 5582
+
+	-- Other specific functionality
+		"bosh"; -- Enable BOSH clients, aka "Jabber over HTTP"
+		"websocket"; -- Websocket support
+		--"httpserver"; -- Serve static files from a directory over HTTP
+		--"groups"; -- Shared roster support
+		--"announce"; -- Send announcement to all online users
+		--"welcome"; -- Welcome users who register accounts
+		--"watchregistrations"; -- Alert admins of registrations
+		--"motd"; -- Send a message to users when they log in
+	-- Debian: do not remove this module, or you lose syslog
+	-- support
+		"posix"; -- POSIX functionality, sends server to background, enables syslog, etc.
+};
+
+-- These modules are auto-loaded, should you
+-- (for some mad reason) want to disable
+-- them then uncomment them below
+modules_disabled = {
+	-- "presence"; -- Route user/contact status information
+	-- "message"; -- Route messages
+	-- "iq"; -- Route info queries
+	-- "offline"; -- Store offline messages
+};
+
+-- Disable account creation by default, for security
+-- For more information see http://prosody.im/doc/creating_accounts
+allow_registration = false;
+
+-- Debian:
+--   send the server to background.
+--
+daemonize = true;
+
+-- Debian:
+--   Please, don't change this option since /var/run/prosody/
+--   is one of the few directories Prosody is allowed to write to
+--
+pidfile = "/var/run/prosody/prosody.pid";
+
+-- These are the SSL/TLS-related settings. If you don't want
+-- to use SSL/TLS, you may comment or remove this
+ssl = {
+	key = "/etc/prosody/certs/localhost.key";
+	certificate = "/etc/prosody/certs/localhost.crt";
+}
+
+-- Only allow encrypted streams? Encryption is already used when
+-- available. These options will cause Prosody to deny connections that
+-- are not encrypted. Note that some servers do not support s2s
+-- encryption or have it disabled, including gmail.com and Google Apps
+-- domains.
+
+--c2s_require_encryption = false
+--s2s_require_encryption = false
+
+-- Select the authentication backend to use. The 'internal' providers
+-- use Prosody's configured data storage to store the authentication data.
+-- To allow Prosody to offer secure authentication mechanisms to clients, the
+-- default provider stores passwords in plaintext. If you do not trust your
+-- server please see http://prosody.im/doc/modules/mod_auth_internal_hashed
+-- for information about using the hashed backend.
+
+authentication = "anonymous"
+
+-- Select the storage backend to use. By default Prosody uses flat files
+-- in its configured data directory, but it also supports more backends
+-- through modules. An "sql" backend is included by default, but requires
+-- additional dependencies. See http://prosody.im/doc/storage for more info.
+
+--storage = "sql" -- Default is "internal"
+
+-- For the "sql" backend, you can uncomment *one* of the below to configure:
+--sql = { driver = "SQLite3", database = "prosody.sqlite" } -- Default. 'database' is the filename.
+--sql = { driver = "MySQL", database = "prosody", username = "prosody", password = "secret", host = "localhost" }
+--sql = { driver = "PostgreSQL", database = "prosody", username = "prosody", password = "secret", host = "localhost" }
+
+-- Logging configuration
+-- For advanced logging see http://prosody.im/doc/logging
+--
+-- Debian:
+--  Logs info and higher to /var/log
+--  Logs errors to syslog also
+log = {
+	-- Log files (change 'info' to 'debug' for debug logs):
+	info = "/var/log/prosody/prosody.log";
+	error = "/var/log/prosody/prosody.err";
+	-- Syslog:
+	{ levels = { "error" }; to = "syslog";  };
+}
+
+----------- Virtual hosts -----------
+-- You need to add a VirtualHost entry for each domain you wish Prosody to serve.
+-- Settings under each VirtualHost entry apply *only* to that host.
+
+-- Setup localhost VirtualHost
+VirtualHost "localhost"
+
+------ Components ------
+-- You can specify components to add hosts that provide special services,
+-- like multi-user conferences, and transports.
+-- For more information on components, see http://prosody.im/doc/components
+
+---Set up a MUC (multi-user chat) room server on conference.example.com:
+Component "conference.localhost" "muc"
+
+-- Set up a SOCKS5 bytestream proxy for server-proxied file transfers:
+--Component "proxy.example.com" "proxy65"
+
+---Set up an external component (default component port is 5347)
+--
+-- External components allow adding various services, such as gateways/
+-- transports to other networks like ICQ, MSN and Yahoo. For more info
+-- see: http://prosody.im/doc/components#adding_an_external_component
+--
+--Component "gateway.example.com"
+--	component_secret = "password"
+
+------ Additional config files ------
+-- For organizational purposes you may prefer to add VirtualHost and
+-- Component definitions in their own config files. This line includes
+-- all config files in /etc/prosody/conf.d/
+
+Include "conf.d/*.cfg.lua"

--- a/devbox/provisioning.sh
+++ b/devbox/provisioning.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+#
+# Vagrant provisioning script
+#
+# Copyright 2014 Michael Weibel <michael.weibel@gmail.com>
+# License: MIT
+#
+
+#
+# Install Prosody XMPP server
+#
+echo "deb http://packages.prosody.im/debian precise main" > /etc/apt/sources.list.d/prosody.list
+wget https://prosody.im/files/prosody-debian-packages.key -O- | sudo apt-key add -
+apt-get update
+
+apt-get install -y liblua5.1-bitop prosody lua-event
+
+# Install Websockets module
+wget -O /usr/lib/prosody/modules/mod_websocket.lua http://prosody-modules.googlecode.com/hg/mod_websocket/mod_websocket.lua
+
+# Place config
+cp /vagrant/devbox/prosody.cfg.lua /etc/prosody/prosody.cfg.lua
+
+/etc/init.d/prosody restart
+
+#
+# Install nginx for static file serving
+#
+apt-get install -y nginx
+cp /vagrant/devbox/nginx-default.conf /etc/nginx/sites-available/default
+/etc/init.d/nginx restart
+
+ln -fs /vagrant /usr/share/nginx/html/candy
+ln -fs /vagrant/devbox/index.html /usr/share/nginx/html/index.html
+
+#
+# Candy development dependencies
+#
+sudo add-apt-repository ppa:chris-lea/node.js
+sudo apt-get update
+sudo apt-get install -y nodejs
+
+cd /vagrant
+npm install -g grunt-cli
+npm install
+
+#
+# Selenium & PhantomJS for testing
+#
+apt-get install -y openjdk-7-jre
+mkdir /usr/lib/selenium/
+cd /usr/lib/selenium/
+wget http://selenium-release.storage.googleapis.com/2.42/selenium-server-standalone-2.42.2.jar
+mkdir -p /var/log/selenium/
+chmod a+w /var/log/selenium/
+cp /vagrant/devbox/selenium.init.sh /etc/init.d/selenium
+chmod 755 /etc/init.d/selenium
+/etc/init.d/selenium start
+update-rc.d selenium defaults
+apt-get install -y phantomjs

--- a/devbox/selenium.init.sh
+++ b/devbox/selenium.init.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+case "${1:-''}" in
+	'start')
+		if test -f /tmp/selenium.pid
+		then
+			echo "Selenium is already running."
+		else
+			java -jar /usr/lib/selenium/selenium-server-standalone-2.42.2.jar -port 4444 > /var/log/selenium/selenium-output.log 2> /var/log/selenium/selenium-error.log & echo $! > /tmp/selenium.pid
+			echo "Starting Selenium..."
+
+			error=$?
+			if test $error -gt 0
+			then
+				echo "${bon}Error $error! Couldn't start Selenium!${boff}"
+			fi
+		fi
+	;;
+	'stop')
+		if test -f /tmp/selenium.pid
+		then
+			echo "Stopping Selenium..."
+			PID=`cat /tmp/selenium.pid`
+			kill -3 $PID
+			if kill -9 $PID ;
+				then
+					sleep 2
+					test -f /tmp/selenium.pid && rm -f /tmp/selenium.pid
+				else
+					echo "Selenium could not be stopped..."
+				fi
+		else
+			echo "Selenium is not running."
+		fi
+		;;
+	'restart')
+		if test -f /tmp/selenium.pid
+		then
+			kill -HUP `cat /tmp/selenium.pid`
+			test -f /tmp/selenium.pid && rm -f /tmp/selenium.pid
+			sleep 1
+			java -jar /usr/lib/selenium/selenium-server-standalone-2.42.2.jar -port 4444 > /var/log/selenium/selenium-output.log 2> /var/log/selenium/selenium-error.log & echo $! > /tmp/selenium.pid
+			echo "Reload Selenium..."
+		else
+			echo "Selenium isn't running..."
+		fi
+		;;
+	*)      # no parameter specified
+		echo "Usage: $SELF start|stop|restart|reload|force-reload|status"
+		exit 1
+	;;
+esac


### PR DESCRIPTION
Comes from https://github.com/candy-chat/vagrant/pull/1.

There's no convincing reason for this to be excluded from the main reason. The Vagrant environment makes working on Candy easier (provides an XMPP server for testing, Selenium & PhantomJS for automated tests and a ready-made NodeJS environment for building.

This excludes candy-plugins for now. We can figure out how that fits later.
