### PR TITLE
Run unit tests in NodeJS to avoid browser dependency

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -159,7 +159,7 @@ module.exports = function(grunt) {
 			},
 			unit: {
 				options: {
-					runType: 'runner',
+					runType: 'client',
 					config: localInternConfig,
 					functionalSuites: []
 				}

--- a/bower.json
+++ b/bower.json
@@ -31,7 +31,7 @@
     "tests"
   ],
   "dependencies": {
-    "jquery": "~1.10.2",
+    "jquery": "2.1.1",
     "strophe": "1.1.3",
     "strophejs-plugins": "benlangfeld/strophejs-plugins#30fb089457addc37e01d69c3536dee868a90a9ad",
     "mustache": "0.3.0",

--- a/tests/intern.js
+++ b/tests/intern.js
@@ -50,7 +50,7 @@ define({
 		// Packages that should be registered with the loader in each testing environment
 		packages: [
 				{ name: 'candy', location: '.' }
-			, { name: 'jquery', location: 'bower_components/jquery', main: 'jquery'}
+			, { name: 'jquery', location: 'bower_components/jquery/dist', main: 'jquery'}
 			, { name: 'sinon', location: 'node_modules/sinon/lib', main: 'sinon'}
 			, { name: 'sinon-chai', location: 'node_modules/sinon-chai/lib', main: 'sinon-chai'}
 	  ]


### PR DESCRIPTION
Currently breaks on the following error:

```
TypeError: Cannot read property 'defaultView' of undefined
    at Sizzle.setDocument (/Users/ben/code/candy/bower_components/jquery/dist/jquery.js:1015:15)
```

Anyone aware of the solution to this? I figure it has something to do with this:

```
// For CommonJS and CommonJS-like environments where a proper window is present,
// execute the factory and get jQuery
// For environments that do not inherently posses a window with a document
// (such as Node.js), expose a jQuery-making factory as module.exports
// This accentuates the need for the creation of a real window
// e.g. var jQuery = require("jquery")(window);
// See ticket #14549 for more info
```
