### PR TITLE
Added nick parameter to attach.

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -275,8 +275,12 @@ Candy.Core = (function(self, Strophe, $) {
 	 *   (Integer) sid - Session ID
 	 *   (Integer) rid - rid
 	 */
-	self.attach = function(jid, sid, rid) {
-		_user = new self.ChatUser(jid, Strophe.getNodeFromJid(jid));
+	self.attach = function(jid, sid, rid, nick) {
+		if (nick) {
+			_user = new self.ChatUser(jid, nick);
+		} else {
+			_user = new self.ChatUser(jid, Strophe.getNodeFromJid(jid));
+		}
 		self.registerEventHandlers();
 		_connection.attach(jid, sid, rid, Candy.Core.Event.Strophe.Connect);
 	};


### PR DESCRIPTION
The `connect` method allows for a nick to be passed already, this just allows the `attach` method to have that same functionality.
