### PR TITLE
Allow candy admin to display initial message on login form

### DIFF
--- a/res/default.css
+++ b/res/default.css
@@ -646,6 +646,10 @@ ul {
 	margin-left: -330px;
 }
 
+#chat-modal a {
+	color: blue;
+}
+
 #chat-modal span.at-symbol {
 	float: left;
 	padding: 6px;

--- a/res/default.css
+++ b/res/default.css
@@ -641,12 +641,12 @@ ul {
 	color: #333;
 }
 
-#chat-modal.login-with-domains {
+#chat-modal.modal-login-with-domains {
 	width: 650px;
 	margin-left: -330px;
 }
 
-#chat-modal a {
+#chat-modal-body a {
 	color: blue;
 }
 

--- a/res/default.css
+++ b/res/default.css
@@ -575,7 +575,7 @@ ul {
 	width: 15px;
 }
 
-#chat-modal {
+#chat-modal.modal-common {
 	background: #eee;
 	width: 300px;
 	padding: 20px 5px;
@@ -641,7 +641,7 @@ ul {
 	color: #333;
 }
 
-#chat-modal {
+#chat-modal.login-with-domains {
 	width: 650px;
 	margin-left: -330px;
 }

--- a/src/core.js
+++ b/src/core.js
@@ -84,6 +84,11 @@ Candy.Core = (function(self, Strophe, $) {
 			/** Integer: presencePriority
 			 * Default priority for presence messages in order to receive messages across different resources
 			 */
+			/** String: initialMessage
+			 * If non-null, displayed at top of login form.  NB:
+			 * may be replaced with status message when appropriate.
+			 */
+			initialMessage: null,
 			presencePriority: 1,
 			/** String: resource
 			 * JID resource to use when connecting to the server.

--- a/src/core.js
+++ b/src/core.js
@@ -84,11 +84,6 @@ Candy.Core = (function(self, Strophe, $) {
 			/** Integer: presencePriority
 			 * Default priority for presence messages in order to receive messages across different resources
 			 */
-			/** String: initialMessage
-			 * If non-null, displayed at top of login form.  NB:
-			 * may be replaced with status message when appropriate.
-			 */
-			initialMessage: null,
 			presencePriority: 1,
 			/** String: resource
 			 * JID resource to use when connecting to the server.

--- a/src/core.js
+++ b/src/core.js
@@ -63,21 +63,23 @@ Candy.Core = (function(self, Strophe, $) {
 			autojoin: undefined,
 			debug: false,
 			/** List: domains
-			 * If non-null, causes login form to offer this pre-set list of
-             * domains to choose between when logging in.  Any user-provided
-             * domain is discarded and the selected domain is appended.
-             * For each list item, only characters up to the first whitespace
-             * are used, so you can append extra information to each item if
-             * desired.
+			 * If non-null, causes login form to offer this
+                         * pre-set list of domains to choose between when
+                         * logging in.  Any user-provided domain is discarded
+                         * and the selected domain is appended.
+                         * For each list item, only characters up to the first
+                         * whitespace are used, so you can append extra
+                         * information to each item if desired.
 			 */
 			domains: null,
-            /** Boolean: hideDomainList
-              * If true, the domain list defined above is suppressed.  Without
-              * a selector displayed, the default domain (usually the first one
-              * listed) will be used as described above.  Probably only makes
-              * sense with a single domain defined.
-              */
-            hideDomainList: false,
+                        /** Boolean: hideDomainList
+                         * If true, the domain list defined above is suppressed.
+                         * Without a selector displayed, the default domain
+                         * (usually the first one listed) will be used as
+                         * described above.  Probably only makes sense with a
+                         * single domain defined.
+                         */
+                        hideDomainList: false,
 			disableWindowUnload: false,
 			/** Integer: presencePriority
 			 * Default priority for presence messages in order to receive messages across different resources

--- a/src/core.js
+++ b/src/core.js
@@ -63,12 +63,21 @@ Candy.Core = (function(self, Strophe, $) {
 			autojoin: undefined,
 			debug: false,
 			/** List: domains
-			 * If non-null, causes login form to offer this pre-set
-			 * list of domains to choose between when logging in.
-			 * Any user-provided domain is discarded and the
-			 * selected domain is appended
+			 * If non-null, causes login form to offer this pre-set list of
+             * domains to choose between when logging in.  Any user-provided
+             * domain is discarded and the selected domain is appended.
+             * For each list item, only characters up to the first whitespace
+             * are used, so you can append extra information to each item if
+             * desired.
 			 */
 			domains: null,
+            /** Boolean: hideDomainList
+              * If true, the domain list defined above is suppressed.  Without
+              * a selector displayed, the default domain (usually the first one
+              * listed) will be used as described above.  Probably only makes
+              * sense with a single domain defined.
+              */
+            hideDomainList: false,
 			disableWindowUnload: false,
 			/** Integer: presencePriority
 			 * Default priority for presence messages in order to receive messages across different resources

--- a/src/view.js
+++ b/src/view.js
@@ -42,7 +42,12 @@ Candy.View = (function(self, $) {
 				message: { nickname: 15, body: 1000 },
 				roster: { nickname: 15 }
 			},
-			enableXHTML: false
+			enableXHTML: false,
+			/** String: termsMessage
+			 * If non-null, displayed at top of login form.  NB:
+			 * may be replaced with status message when appropriate.
+			 */
+			termsMessage: null
 		},
 
 		/** PrivateFunction: _setupTranslation

--- a/src/view.js
+++ b/src/view.js
@@ -43,11 +43,11 @@ Candy.View = (function(self, $) {
 				roster: { nickname: 15 }
 			},
 			enableXHTML: false,
-			/** String: termsMessage
+			/** String: initialLoginMessage
 			 * If non-null, displayed at top of login form.  NB:
 			 * may be replaced with status message when appropriate.
 			 */
-			termsMessage: null
+			initialLoginMessage: null
 		},
 
 		/** PrivateFunction: _setupTranslation

--- a/src/view/observer.js
+++ b/src/view/observer.js
@@ -316,8 +316,8 @@ Candy.View.Observer = (function(self, $) {
 	 *   (Object) args - {presetJid}
 	 */
 	self.Login = function(event, args) {
-		var termsMsg = Candy.View.getOptions().termsMessage;
-		Candy.View.Pane.Chat.Modal.showLoginForm(termsMsg, args.presetJid);
+		var initialLoginMessage = Candy.View.getOptions().initialLoginMessage;
+		Candy.View.Pane.Chat.Modal.showLoginForm(initialLoginMessage, args.presetJid);
 	};
 
 	/** Class: Candy.View.Observer.AutojoinMissing

--- a/src/view/observer.js
+++ b/src/view/observer.js
@@ -316,7 +316,7 @@ Candy.View.Observer = (function(self, $) {
 	 *   (Object) args - {presetJid}
 	 */
 	self.Login = function(event, args) {
-		var init_msg = Candy.Core.getOptions()['initialMessage'];
+		var init_msg = Candy.Core.getOptions().initialMessage;
 		Candy.View.Pane.Chat.Modal.showLoginForm(init_msg, args.presetJid);
 	};
 

--- a/src/view/observer.js
+++ b/src/view/observer.js
@@ -316,8 +316,8 @@ Candy.View.Observer = (function(self, $) {
 	 *   (Object) args - {presetJid}
 	 */
 	self.Login = function(event, args) {
-		var init_msg = Candy.Core.getOptions().initialMessage;
-		Candy.View.Pane.Chat.Modal.showLoginForm(init_msg, args.presetJid);
+		var termsMsg = Candy.View.getOptions().termsMessage;
+		Candy.View.Pane.Chat.Modal.showLoginForm(termsMsg, args.presetJid);
 	};
 
 	/** Class: Candy.View.Observer.AutojoinMissing

--- a/src/view/observer.js
+++ b/src/view/observer.js
@@ -316,7 +316,8 @@ Candy.View.Observer = (function(self, $) {
 	 *   (Object) args - {presetJid}
 	 */
 	self.Login = function(event, args) {
-		Candy.View.Pane.Chat.Modal.showLoginForm(null, args.presetJid);
+		var init_msg = Candy.Core.getOptions()['initialMessage'];
+		Candy.View.Pane.Chat.Modal.showLoginForm(init_msg, args.presetJid);
 	};
 
 	/** Class: Candy.View.Observer.AutojoinMissing

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -435,8 +435,9 @@ Candy.View.Pane = (function(self, $) {
        *   (String) html - HTML code to put into the modal window
        *   (Boolean) showCloseControl - set to true if a close button should be displayed [default false]
        *   (Boolean) showSpinner - set to true if a loading spinner should be shown [default false]
+       *   (String) modalClass - custom class (or space-separate classes) to attach to the modal
        */
-      show: function(html, showCloseControl, showSpinner) {
+      show: function(html, showCloseControl, showSpinner, modalClass) {
         if(showCloseControl) {
           self.Chat.Modal.showCloseControl();
         } else {
@@ -446,6 +447,13 @@ Candy.View.Pane = (function(self, $) {
           self.Chat.Modal.showSpinner();
         } else {
           self.Chat.Modal.hideSpinner();
+        }
+        // Reset classes to 'modal-common' only in case .show() is called
+        // with different arguments before .hide() can remove the last applied
+        // custom class
+        $('#chat-modal').removeClass().addClass( 'modal-common' );
+        if( modalClass ) {
+          $('#chat-modal').addClass( modalClass );
         }
         $('#chat-modal').stop(false, true);
         $('#chat-modal-body').html(html);
@@ -460,6 +468,8 @@ Candy.View.Pane = (function(self, $) {
        *   (Function) callback - Calls the specified function after modal window has been hidden.
        */
       hide: function(callback) {
+        // Reset classes to include only `modal-common`.
+        $('#chat-modal').removeClass().addClass( 'modal-common' );
         $('#chat-modal').fadeOut('fast', function() {
           $('#chat-modal-body').text('');
           $('#chat-modal-overlay').hide();
@@ -527,6 +537,7 @@ Candy.View.Pane = (function(self, $) {
         var domains = Candy.Core.getOptions().domains;
         domains = domains ? domains.map( function(d) {return {'domain':d};} )
                            : null;
+        var customClass = domains ? 'login-with-domains' : null;
         self.Chat.Modal.show((message ? message : '') + Mustache.to_html(Candy.View.Template.Login.form, {
           _labelNickname: $.i18n._('labelNickname'),
           _labelUsername: $.i18n._('labelUsername'),
@@ -538,7 +549,7 @@ Candy.View.Pane = (function(self, $) {
           displayDomain: domains ? true : false,
           displayNickname: Candy.Core.isAnonymousConnection(),
           presetJid: presetJid ? presetJid : false
-        }));
+        }), null, null, customClass);
         $('#login-form').children(':input:first').focus();
 
         // register submit handler

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -538,7 +538,7 @@ Candy.View.Pane = (function(self, $) {
         var hideDomainList = Candy.Core.getOptions().hideDomainList;
         domains = domains ? domains.map( function(d) {return {'domain':d};} )
                            : null;
-        var customClass = domains && !hideDomainList ? 'login-with-domains'
+        var customClass = domains && !hideDomainList ? 'modal-login-with-domains'
                                                      : null;
         self.Chat.Modal.show((message ? message : '') + Mustache.to_html(Candy.View.Template.Login.form, {
           _labelNickname: $.i18n._('labelNickname'),

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -552,7 +552,7 @@ Candy.View.Pane = (function(self, $) {
             var jid;
             if(domain) { // domain is stipulated
               // Ensure there is no domain part in username
-              username = Strophe.getNodeFromJid( username );
+              username = username.split('@')[0];
               jid = username + '@' + domain;
             } else {  // domain not stipulated
               // guess the input and create a jid out of it

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -550,13 +550,13 @@ Candy.View.Pane = (function(self, $) {
 
           if (!Candy.Core.isAnonymousConnection()) {
             var jid;
-            if( domain ) { // domain is stipulated
-                // Ensure there is no domain part in username
-                username = username.split('@')[0];
-                jid = username + '@' + domain;
+            if(domain) { // domain is stipulated
+              // Ensure there is no domain part in username
+              username = Strophe.getNodeFromJid( username );
+              jid = username + '@' + domain;
             } else {  // domain not stipulated
-                // guess the input and create a jid out of it
-                jid = Candy.Core.getUser() && username.indexOf("@") < 0 ?
+              // guess the input and create a jid out of it
+              jid = Candy.Core.getUser() && username.indexOf("@") < 0 ?
               username + '@' + Strophe.getDomainFromJid(Candy.Core.getUser().getJid()) : username;
             }
 
@@ -989,5 +989,3 @@ Candy.View.Pane = (function(self, $) {
 
   return self;
 }(Candy.View.Pane || {}, jQuery));
-
-// vim: ts=4 softtabstop=4 shiftwidth=4 expandtab

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -451,9 +451,9 @@ Candy.View.Pane = (function(self, $) {
         // Reset classes to 'modal-common' only in case .show() is called
         // with different arguments before .hide() can remove the last applied
         // custom class
-        $('#chat-modal').removeClass().addClass( 'modal-common' );
+        $('#chat-modal').removeClass().addClass('modal-common');
         if( modalClass ) {
-          $('#chat-modal').addClass( modalClass );
+          $('#chat-modal').addClass(modalClass);
         }
         $('#chat-modal').stop(false, true);
         $('#chat-modal-body').html(html);
@@ -469,7 +469,7 @@ Candy.View.Pane = (function(self, $) {
        */
       hide: function(callback) {
         // Reset classes to include only `modal-common`.
-        $('#chat-modal').removeClass().addClass( 'modal-common' );
+        $('#chat-modal').removeClass().addClass('modal-common');
         $('#chat-modal').fadeOut('fast', function() {
           $('#chat-modal-body').text('');
           $('#chat-modal-overlay').hide();

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -535,9 +535,11 @@ Candy.View.Pane = (function(self, $) {
        */
       showLoginForm: function(message, presetJid) {
         var domains = Candy.Core.getOptions().domains;
+        var hideDomainList = Candy.Core.getOptions().hideDomainList;
         domains = domains ? domains.map( function(d) {return {'domain':d};} )
                            : null;
-        var customClass = domains ? 'login-with-domains' : null;
+        var customClass = domains && !hideDomainList ? 'login-with-domains'
+                                                     : null;
         self.Chat.Modal.show((message ? message : '') + Mustache.to_html(Candy.View.Template.Login.form, {
           _labelNickname: $.i18n._('labelNickname'),
           _labelUsername: $.i18n._('labelUsername'),
@@ -550,6 +552,10 @@ Candy.View.Pane = (function(self, $) {
           displayNickname: Candy.Core.isAnonymousConnection(),
           presetJid: presetJid ? presetJid : false
         }), null, null, customClass);
+        if(hideDomainList) {
+          $('#domain').hide();
+          $('.at-symbol').hide();
+        }
         $('#login-form').children(':input:first').focus();
 
         // register submit handler


### PR DESCRIPTION
Builds on PR #303, adds core option `initialMessage` which is displayed at top of login form when user first presented with it.  This message will be replaced by 'login failed' as appropriate.

Intended for things like link to Ts & Cs and/or special information relating to fixed domains (PR #303).