### PR TITLE
Add roomJid to renderEvt data for before-render trigger.

### DIFF
--- a/src/view/pane/message.js
+++ b/src/view/pane/message.js
@@ -148,7 +148,8 @@ Candy.View.Pane = (function(self, $) {
           displayName: Candy.Util.crop(name, Candy.View.getOptions().crop.message.nickname),
           message: message,
           time: Candy.Util.localizedTime(timestamp),
-          timestamp: timestamp.toISOString()
+          timestamp: timestamp.toISOString(),
+          roomjid: roomJid
         }
       };
 


### PR DESCRIPTION
It's included in the other message triggers, but not in `before-render`. Makes life simpler.
