### PR TITLE
Move unread message notifications to a plugin

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -62,6 +62,11 @@ Candy.Core = (function(self, Strophe, $) {
 			 */
 			autojoin: undefined,
 			debug: false,
+			/** Boolean: disableCoreNotifications
+			 * If set to `true`, the built-in notifications (sounds and badges) are disabled.
+			 * This is useful if you are using a plugin to handle notifications.
+			 */
+			disableCoreNotifications: false,
 			disableWindowUnload: false,
 			/** Integer: presencePriority
 			 * Default priority for presence messages in order to receive messages across different resources

--- a/src/view/pane/message.js
+++ b/src/view/pane/message.js
@@ -161,7 +161,8 @@ Candy.View.Pane = (function(self, $) {
        *                           - (String) name - Name of the sending user
        *                           - (String) displayName - Cropped name of the sending user
        *                           - (String) message - Message text
-       *                           - (String) time - Localized time
+       *                           - (String) time - Localized time of message
+       *                           - (String) timestamp - ISO formatted timestamp of message
        */
       $(Candy).triggerHandler('candy:view.message.before-render', renderEvtData);
 
@@ -180,13 +181,39 @@ Candy.View.Pane = (function(self, $) {
         }
       });
 
-      // Notify the user about a new private message
-      if(Candy.View.getCurrent().roomJid !== roomJid || !self.Window.hasFocus()) {
-        self.Chat.increaseUnreadMessages(roomJid);
-        if(Candy.View.Pane.Chat.rooms[roomJid].type === 'chat' && !self.Window.hasFocus()) {
-          self.Chat.Toolbar.playSound();
+      var notifyEvtData = {
+        name: name,
+        displayName: Candy.Util.crop(name, Candy.View.getOptions().crop.message.nickname),
+        roomJid: roomJid,
+        message: message,
+        time: Candy.Util.localizedTime(timestamp),
+        timestamp: timestamp.toISOString()
+      };
+      /** Event: candy:view.message.notify
+       * Notify the user (optionally) that a new message has been received
+       *
+       * Parameters:
+       *   (Object) templateData - Template data consists of:
+       *                           - (String) name - Name of the sending user
+       *                           - (String) displayName - Cropped name of the sending user
+       *                           - (String) roomJid - JID into which the message was sent
+       *                           - (String) message - Message text
+       *                           - (String) time - Localized time of message
+       *                           - (String) timestamp - ISO formatted timestamp of message
+       */
+      $(Candy).triggerHandler('candy:view.message.notify', notifyEvtData);
+
+      // Check to see if in-core notifications are disabled
+      if(!Candy.Core.getOptions().disableCoreNotifications) {
+        // Notify the user about a new private message
+        if(Candy.View.getCurrent().roomJid !== roomJid || !self.Window.hasFocus()) {
+          self.Chat.increaseUnreadMessages(roomJid);
+          if(Candy.View.Pane.Chat.rooms[roomJid].type === 'chat' && !self.Window.hasFocus()) {
+            self.Chat.Toolbar.playSound();
+          }
         }
       }
+
       if(Candy.View.getCurrent().roomJid === roomJid) {
         self.Room.scrollToBottom(roomJid);
       }


### PR DESCRIPTION
In our Candy app we have some business rules that need to be applied to determine the number of unread messages.  Part of it is the ability to check whether a message has been read on another device so we don't show activity indicators on login for something the user has already seen.  To make this work, we need to be able to determine whether to show an activity indicator in a plugin, rather than in Candy core.  This PR creates a new event, `candy:view.message.notify` that contains information relevant to whether and how a message should create notifications.

Corresponding plugin change at candy-chat/candy-plugins#125
