### PR TITLE
Fix Autodisconnect On All Tabs Closed

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -59,6 +59,11 @@ Candy.Core = (function(self, Strophe, $) {
 			 * You may want to define an array of rooms to autojoin: `['room1@conference.host.tld', 'room2...]` (ejabberd, Openfire, ...)
 			 */
 			autojoin: undefined,
+			/** Boolean: disconnectWithoutTabs
+			 * If you set to `false`, when you close all of the tabs, the service does not disconnect.
+			 * Set to `true`, when you close all of the tabs, the service will disconnect.
+			 */
+			disconnectWithoutTabs: true,
 			/** String: conferenceDomain
 			 * Holds the prefix for an XMPP chat server's conference subdomain.
 			 * If not set, assumes no specific subdomain.

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -175,9 +175,11 @@ Candy.View.Pane = (function(self, $) {
      *   (Boolean) - false, this will stop the event from bubbling
      */
     allTabsClosed: function() {
-      Candy.Core.disconnect();
-      self.Chat.Toolbar.hide();
-      return;
+      if (Candy.Core.getOptions().disconnectWithoutTabs) {
+        Candy.Core.disconnect();
+        self.Chat.Toolbar.hide();
+        return;
+      }
     },
 
     /** Function: fitTabs


### PR DESCRIPTION
Added an `autoDisconnect` boolean option to `Candy.init()` that defaults to `true` (the current behavior) that can be set to `false`.
