### PR TITLE
Autodisable Scroll

### DIFF
--- a/src/view/pane/message.js
+++ b/src/view/pane/message.js
@@ -109,6 +109,11 @@ Candy.View.Pane = (function(self, $) {
         timestamp = Candy.Util.iso8601toDate(timestamp);
       }
 
+      // Before we add the new message, check to see if we should be automatically scrolling or not.
+      var messagePane = self.Room.getPane(roomJid, '.message-pane');
+      var enableScroll = (messagePane.scrollTop() + messagePane.outerHeight()) === messagePane.prop('scrollHeight');
+      Candy.View.Pane.Chat.rooms[roomJid].enableScroll = enableScroll;
+
       var evtData = {
         'roomJid': roomJid,
         'name': name,

--- a/src/view/pane/room.js
+++ b/src/view/pane/room.js
@@ -298,8 +298,13 @@ Candy.View.Pane = (function(self, $) {
      *   (String) roomJid - Room JID
      */
     onScrollToBottom: function(roomJid) {
-      var messagePane = self.Room.getPane(roomJid, '.message-pane-wrapper');
-      messagePane.scrollTop(messagePane.prop('scrollHeight'));
+      var messagePane = self.Room.getPane(roomJid, '.message-pane');
+
+      if (Candy.View.Pane.Chat.rooms[roomJid].enableScroll === true) {
+        messagePane.scrollTop(messagePane.prop('scrollHeight'));
+      } else {
+        return false;
+      }
     },
 
     /** Function: onScrollToStoredPosition


### PR DESCRIPTION
When we have scrolled up in chat, disable automatic scrolling to the bottom. When we scroll back down, automatically re-enable it.
