### PR TITLE
Bugfix for Scroll When Showing Previously Shown Chatroom

### DIFF
--- a/src/view/pane/message.js
+++ b/src/view/pane/message.js
@@ -111,7 +111,7 @@ Candy.View.Pane = (function(self, $) {
 
       // Before we add the new message, check to see if we should be automatically scrolling or not.
       var messagePane = self.Room.getPane(roomJid, '.message-pane');
-      var enableScroll = (messagePane.scrollTop() + messagePane.outerHeight()) === messagePane.prop('scrollHeight');
+      var enableScroll = ((messagePane.scrollTop() + messagePane.outerHeight()) === messagePane.prop('scrollHeight')) || !$(messagePane).is(':visible');
       Candy.View.Pane.Chat.rooms[roomJid].enableScroll = enableScroll;
 
       var evtData = {


### PR DESCRIPTION
This makes sure that `scrollToBottom(roomJid)` is allowed to scroll the window to the bottom when re-showing it.