### PR TITLE
show xhtmlMessage to self in private conversations

### DIFF
--- a/src/view/pane/message.js
+++ b/src/view/pane/message.js
@@ -74,7 +74,7 @@ Candy.View.Pane = (function(self, $) {
       Candy.Core.Action.Jabber.Room.Message(targetJid, message, roomType, xhtmlMessage);
       // Private user chat. Jabber won't notify the user who has sent the message. Just show it as the user hits the button...
       if(roomType === 'chat' && message) {
-        self.Message.show(roomJid, self.Room.getUser(roomJid).getNick(), message, undefined, undefined, Candy.Core.getUser().getJid());
+        self.Message.show(roomJid, self.Room.getUser(roomJid).getNick(), message, xhtmlMessage, undefined, Candy.Core.getUser().getJid());
       }
       // Clear input and set focus to it
       $(this).children('.field').val('').focus();


### PR DESCRIPTION
Alright, hopefully I've got the submission steps correct this time.

Users were reporting candy-plugins/colors-xhtml plugin was not having an effect with private messages they sent. Actually, the xhtmlMessage wasn't getting sent back to their own screen.