### PR TITLE
Allow links to render correctly in adminMessage and infoMessage

### DIFF
--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -215,11 +215,9 @@ Candy.View.Pane = (function(self, $) {
      */
     adminMessage: function(subject, message) {
       if(Candy.View.getCurrent().roomJid) { // Simply dismiss admin message if no room joined so far. TODO: maybe we should show those messages on a dedicated pane?
+        message = Candy.Util.Parser.all(message.substring(0, Candy.View.getOptions().crop.message.body));
         if(Candy.View.getOptions().enableXHTML === true) {
           message = Candy.Util.parseAndCropXhtml(message, Candy.View.getOptions().crop.message.body);
-        }
-        else {
-          message = Candy.Util.Parser.all(message.substring(0, Candy.View.getOptions().crop.message.body));
         }
         var timestamp = new Date();
         var html = Mustache.to_html(Candy.View.Template.Chat.adminMessage, {
@@ -270,11 +268,9 @@ Candy.View.Pane = (function(self, $) {
      */
     onInfoMessage: function(roomJid, subject, message) {
       if(Candy.View.getCurrent().roomJid && self.Chat.rooms[roomJid]) { // Simply dismiss info message if no room joined so far. TODO: maybe we should show those messages on a dedicated pane?
+        message = Candy.Util.Parser.all(message.substring(0, Candy.View.getOptions().crop.message.body));
         if(Candy.View.getOptions().enableXHTML === true) {
           message = Candy.Util.parseAndCropXhtml(message, Candy.View.getOptions().crop.message.body);
-        }
-        else {
-          message = Candy.Util.Parser.all(message.substring(0, Candy.View.getOptions().crop.message.body));
         }
         var timestamp = new Date();
         var html = Mustache.to_html(Candy.View.Template.Chat.infoMessage, {

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -215,6 +215,12 @@ Candy.View.Pane = (function(self, $) {
      */
     adminMessage: function(subject, message) {
       if(Candy.View.getCurrent().roomJid) { // Simply dismiss admin message if no room joined so far. TODO: maybe we should show those messages on a dedicated pane?
+        if(Candy.View.getOptions().enableXHTML === true) {
+          message = Candy.Util.parseAndCropXhtml(message, Candy.View.getOptions().crop.message.body);
+        }
+        else {
+          message = Candy.Util.Parser.all(message.substring(0, Candy.View.getOptions().crop.message.body));
+        }
         var timestamp = new Date();
         var html = Mustache.to_html(Candy.View.Template.Chat.adminMessage, {
           subject: subject,
@@ -264,6 +270,12 @@ Candy.View.Pane = (function(self, $) {
      */
     onInfoMessage: function(roomJid, subject, message) {
       if(Candy.View.getCurrent().roomJid && self.Chat.rooms[roomJid]) { // Simply dismiss info message if no room joined so far. TODO: maybe we should show those messages on a dedicated pane?
+        if(Candy.View.getOptions().enableXHTML === true) {
+          message = Candy.Util.parseAndCropXhtml(message, Candy.View.getOptions().crop.message.body);
+        }
+        else {
+          message = Candy.Util.Parser.all(message.substring(0, Candy.View.getOptions().crop.message.body));
+        }
         var timestamp = new Date();
         var html = Mustache.to_html(Candy.View.Template.Chat.infoMessage, {
           subject: subject,

--- a/src/view/template.js
+++ b/src/view/template.js
@@ -38,9 +38,9 @@ Candy.View.Template = (function(self){
 				'</div><div id="chat-modal-overlay"></div>',
 		adminMessage: '<li><small data-timestamp="{{timestamp}}">{{time}}</small><div class="adminmessage">' +
 				'<span class="label">{{sender}}</span>' +
-				'<span class="spacer">▸</span>{{subject}} {{message}}</div></li>',
+				'<span class="spacer">▸</span>{{subject}} {{{message}}}</div></li>',
 		infoMessage: '<li><small data-timestamp="{{timestamp}}">{{time}}</small><div class="infomessage">' +
-				'<span class="spacer">•</span>{{subject}} {{message}}</div></li>',
+				'<span class="spacer">•</span>{{subject}} {{{message}}}</div></li>',
 		toolbar: '<ul id="chat-toolbar">' +
 				'<li id="emoticons-icon" data-tooltip="{{tooltipEmoticons}}"></li>' +
 				'<li id="chat-sound-control" class="checked" data-tooltip="{{tooltipSound}}">{{> soundcontrol}}</li>' +


### PR DESCRIPTION
Currently, messages with links show escaped html