### PR TITLE
Prosody does not serve 'html[xmlns] body[xmlns]' to MSIE

### DIFF
--- a/src/core/event.js
+++ b/src/core/event.js
@@ -794,7 +794,7 @@ Candy.Core.Event = (function(self, Strophe, $) {
 
 					var xhtmlChild = msg.children('html[xmlns="' + Strophe.NS.XHTML_IM + '"]');
 					if(xhtmlChild.length > 0) {
-						var xhtmlMessage = $($('<div>').append(xhtmlChild.children('body[xmlns="' + Strophe.NS.XHTML + '"]').first().contents()).html());
+						var xhtmlMessage = $($('<div>').append(xhtmlChild.children('body').first().contents()).html());
 						message.xhtmlMessage = xhtmlMessage;
 					}
 


### PR DESCRIPTION
... just 'html[xmlns] body'. Current code means MSIE will never render such xhtml messages.