### PR TITLE
Better mobile experience for emoticons menu.

### DIFF
--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -994,6 +994,9 @@ Candy.View.Pane = (function(self, $) {
             value = input.val(),
             emoticon = $(this).attr('alt') + ' ';
           input.val(value ? value + ' ' + emoticon : emoticon).focus();
+
+          // Once you make a selction, hide the menu.
+          menu.hide();
         });
 
         var posLeft = Candy.Util.getPosLeftAccordingToWindowBounds(menu, pos.left),


### PR DESCRIPTION
Just close it after you click on an emoticon. Simple. :)

On mobile, without this, the browser can't tell if we've "moused out" of the tooltip. We need a way for a mobile user to be able to clear this emoticon box away once they've selected it.