### PR TITLE
allow parenthesis in linkify

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -510,6 +510,7 @@ Candy.Util = (function(self, $){
 
 		/** Function: linkify
 		 * Replaces URLs with a HTML-link.
+		 * big regex adapted from https://gist.github.com/dperini/729294 - Diego Perini, MIT license.
 		 *
 		 * Parameters:
 		 *   (String) text - Text to linkify
@@ -519,7 +520,7 @@ Candy.Util = (function(self, $){
 		 */
 		linkify: function(text) {
 			text = text.replace(/(^|[^\/])(www\.[^\.]+\.[\S]+(\b|$))/gi, '$1http://$2');
-			return text.replace(/(\b(https?|ftp|file):\/\/[\-A-Z0-9+&@#\/\[\]%?=~_|!:,.;\)\(]*[\-A-Z0-9+&@#\/%=~_|\)\(])/ig, '<a href="$1" target="_blank">$1</a>');
+			return text.replace(/(\b(?:(?:https?|ftp|file):\/\/)(?:\S+(?::\S*)?@)?(?:(?!(?:10|127)(?:\.\d{1,3}){3})(?!(?:169\.254|192\.168)(?:\.\d{1,3}){2})(?!172\.(?:1[6-9]|2\d|3[0-1])(?:\.\d{1,3}){2})(?:1\d\d|2[01]\d|22[0-3]|[1-9]\d?)(?:\.(?:1?\d{1,2}|2[0-4]\d|25[0-5])){2}(?:\.(?:[1-9]\d?|1\d\d|2[0-4]\d|25[0-4]))|(?:(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)(?:\.(?:[a-z\u00a1-\uffff0-9]-*)*[a-z\u00a1-\uffff0-9]+)*(?:\.(?:[a-z\u00a1-\uffff]{2,})))(?::\d{2,5})?(?:\/\S*)?)/gi, '<a href="$1" target="_blank">$1</a>');
 		},
 
 		/** Function: escape

--- a/src/util.js
+++ b/src/util.js
@@ -519,7 +519,7 @@ Candy.Util = (function(self, $){
 		 */
 		linkify: function(text) {
 			text = text.replace(/(^|[^\/])(www\.[^\.]+\.[\S]+(\b|$))/gi, '$1http://$2');
-			return text.replace(/(\b(https?|ftp|file):\/\/[\-A-Z0-9+&@#\/\[\]%?=~_|!:,.;]*[\-A-Z0-9+&@#\/%=~_|])/ig, '<a href="$1" target="_blank">$1</a>');
+			return text.replace(/(\b(https?|ftp|file):\/\/[\-A-Z0-9+&@#\/\[\]%?=~_|!:,.;\)\(]*[\-A-Z0-9+&@#\/%=~_|\)\(])/ig, '<a href="$1" target="_blank">$1</a>');
 		},
 
 		/** Function: escape


### PR DESCRIPTION
Links like http://en.wikipedia.org/wiki/Sweets_(disambiguation) - in which parenthesis _should_ be encoded, but aren't always - were only being partially detected.