### PR TITLE
Feature: warning and error logging

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -508,5 +508,21 @@ Candy.Core = (function(self, Strophe, $) {
 	 */
 	self.log = function() {};
 
+	/** Function: warn
+	 * Print a message to the browser's "info" log
+	 * Enabled regardless of debug mode
+	 */
+	self.warn = function() {
+		Function.prototype.apply.call(console.warn, console, arguments);
+	}
+
+	/** Function: error
+	 * Print a message to the browser's "error" log
+	 * Enabled regardless of debug mode
+	 */
+	self.warn = function() {
+		Function.prototype.apply.call(console.error, console, arguments);
+	}
+
 	return self;
 }(Candy.Core || {}, Strophe, jQuery));

--- a/src/core.js
+++ b/src/core.js
@@ -514,15 +514,15 @@ Candy.Core = (function(self, Strophe, $) {
 	 */
 	self.warn = function() {
 		Function.prototype.apply.call(console.warn, console, arguments);
-	}
+	};
 
 	/** Function: error
 	 * Print a message to the browser's "error" log
 	 * Enabled regardless of debug mode
 	 */
-	self.warn = function() {
+	self.error = function() {
 		Function.prototype.apply.call(console.error, console, arguments);
-	}
+	};
 
 	return self;
 }(Candy.Core || {}, Strophe, jQuery));

--- a/src/core/event.js
+++ b/src/core/event.js
@@ -98,7 +98,7 @@ Candy.Core.Event = (function(self, Strophe, $) {
 					break;
 
 				default:
-					Candy.Core.log('[Connection] What?!');
+					Candy.Core.warn('[Connection] Unknown status received:', status);
 					break;
 			}
 			/** Event: candy:core.chat.connection

--- a/src/util.js
+++ b/src/util.js
@@ -629,8 +629,7 @@ Candy.Util = (function(self, $){
 						el.append(self.createHtml(elem.childNodes[i], maxLength, currentLength));
 					}
 				} catch(e) { // invalid elements
-					Candy.Core.log("[Util:createHtml] Error while parsing XHTML:");
-					Candy.Core.log(e);
+					Candy.Core.warn("[Util:createHtml] Error while parsing XHTML:", e);
 					el = Strophe.xmlTextNode('');
 				}
 			} else {


### PR DESCRIPTION
Add `Candy.Core.warn()` and `Candy.Core.error()` logging levels. This will allow Candy Core as well as plugins to log important error messages without turning on all of the debugging that can flood the console.