### PR TITLE
Fix incorrect JID resource with Websockets

### DIFF
--- a/src/core.js
+++ b/src/core.js
@@ -284,6 +284,12 @@ Candy.Core = (function(self, Strophe, $) {
 		_anonymousConnection = !_anonymousConnection ? jidOrHost && jidOrHost.indexOf("@") < 0 : true;
 
 		if(jidOrHost && password) {
+			// Respect the resource, if provided
+			var resource = Strophe.getResourceFromJid(jidOrHost);
+			if (resource) {
+				_options.resource = resource;
+			}
+
 			// authentication
 			_connection.connect(_getEscapedJidFromJid(jidOrHost) + '/' + _options.resource, password, Candy.Core.Event.Strophe.Connect);
 			if (nick) {


### PR DESCRIPTION
This commit makes the connect function check the provided JID for a resource. Without this, Candy connects with the default resource of “Candy”, then causes a stream error when sending the first stanza with a from containing the full JID.