### PR TITLE
Bugfix: infoMessage()/onInfoMessage() calls

### DIFF
--- a/src/view/observer.js
+++ b/src/view/observer.js
@@ -288,7 +288,7 @@ Candy.View.Observer = (function(self, $) {
 			}
 			Candy.View.Pane.Room.setSubject(args.roomJid, args.message.body);
 		} else if(args.message.type === 'info') {
-			Candy.View.Pane.Chat.infoMessage(args.roomJid, args.message.body);
+			Candy.View.Pane.Chat.infoMessage(args.roomJid, null, args.message.body);
 		} else {
 			// Initialize room if it's a message for a new private user chat
 			if(args.message.type === 'chat' && !Candy.View.Pane.Chat.rooms[args.roomJid]) {

--- a/src/view/pane/chat.js
+++ b/src/view/pane/chat.js
@@ -291,6 +291,7 @@ Candy.View.Pane = (function(self, $) {
      *   (String) message - Message
      */
     onInfoMessage: function(roomJid, subject, message) {
+      message = message || '';
       if(Candy.View.getCurrent().roomJid && self.Chat.rooms[roomJid]) { // Simply dismiss info message if no room joined so far. TODO: maybe we should show those messages on a dedicated pane?
         message = Candy.Util.Parser.all(message.substring(0, Candy.View.getOptions().crop.message.body));
         if(Candy.View.getOptions().enableXHTML === true) {

--- a/src/view/pane/roster.js
+++ b/src/view/pane/roster.js
@@ -106,9 +106,9 @@ Candy.View.Pane = (function(self, $) {
         self.Roster.leaveAnimation('user-' + roomId + '-' + userId);
         // always show leave message in private room, even if status messages have been disabled
         if (self.Chat.rooms[roomJid].type === 'chat') {
-          self.Chat.onInfoMessage(roomJid, $.i18n._('userLeftRoom', [user.getNick()]));
+          self.Chat.onInfoMessage(roomJid, null, $.i18n._('userLeftRoom', [user.getNick()]));
         } else {
-          self.Chat.infoMessage(roomJid, $.i18n._('userLeftRoom', [user.getNick()]), '');
+          self.Chat.infoMessage(roomJid, null, $.i18n._('userLeftRoom', [user.getNick()]), '');
         }
 
       } else if(action === 'nickchange') {
@@ -117,15 +117,15 @@ Candy.View.Pane = (function(self, $) {
         self.Room.changeDataUserJidIfUserIsMe(roomId, user);
         self.PrivateRoom.changeNick(roomJid, user);
         var infoMessage = $.i18n._('userChangedNick', [user.getPreviousNick(), user.getNick()]);
-        self.Chat.infoMessage(roomJid, infoMessage);
+        self.Chat.infoMessage(roomJid, null, infoMessage);
       // user has been kicked
       } else if(action === 'kick') {
         self.Roster.leaveAnimation('user-' + roomId + '-' + userId);
-        self.Chat.onInfoMessage(roomJid, $.i18n._('userHasBeenKickedFromRoom', [user.getNick()]));
+        self.Chat.onInfoMessage(roomJid, null, $.i18n._('userHasBeenKickedFromRoom', [user.getNick()]));
       // user has been banned
       } else if(action === 'ban') {
         self.Roster.leaveAnimation('user-' + roomId + '-' + userId);
-        self.Chat.onInfoMessage(roomJid, $.i18n._('userHasBeenBannedFromRoom', [user.getNick()]));
+        self.Chat.onInfoMessage(roomJid, null, $.i18n._('userHasBeenBannedFromRoom', [user.getNick()]));
       }
 
       // Update user count
@@ -232,9 +232,9 @@ Candy.View.Pane = (function(self, $) {
         if(currentUser !== undefined && user.getNick() !== currentUser.getNick() && self.Room.getUser(roomJid)) {
           // always show join message in private room, even if status messages have been disabled
           if (self.Chat.rooms[roomJid].type === 'chat') {
-            self.Chat.onInfoMessage(roomJid, $.i18n._('userJoinedRoom', [user.getNick()]));
+            self.Chat.onInfoMessage(roomJid, null, $.i18n._('userJoinedRoom', [user.getNick()]));
           } else {
-            self.Chat.infoMessage(roomJid, $.i18n._('userJoinedRoom', [user.getNick()]));
+            self.Chat.infoMessage(roomJid, null, $.i18n._('userJoinedRoom', [user.getNick()]));
           }
         }
       }


### PR DESCRIPTION
`infoMessage(roomJid, subject, message)`/`onInfoMessage(roomJid, subject, message)` are being called with only two parameters in a handful of locations. This fixes that.