### PR TITLE
Fix handling an empty priority

### DIFF
--- a/src/core/contact.js
+++ b/src/core/contact.js
@@ -112,7 +112,12 @@ Candy.Core.Contact.prototype.getStatus = function() {
     highestResourcePriority;
 
   $.each(this.data.resources, function(resource, obj) {
-    var resourcePriority = parseInt(obj.priority, 10);
+    var resourcePriority;
+    if (obj.priority === undefined || obj.priority === '') {
+      resourcePriority = 0;
+    } else {
+      resourcePriority = parseInt(obj.priority, 10);
+    }
 
     if (obj.show === '' || obj.show === null || obj.show === undefined) {
       // TODO: Submit this as a bugfix to strophejs-plugins' roster plugin

--- a/tests/candy/unit/core/contact.js
+++ b/tests/candy/unit/core/contact.js
@@ -47,6 +47,22 @@ define([
       expect(contact.getGroups()).to.eql(['Friends']);
     });
 
+    bdd.it('defaults the priority to 0 when not defined', function() {
+     contact.data.resources = {
+       'resource1': {
+          show: 'away',
+          status: 'Hanging out',
+          priority: 0
+        },
+       'resource2': {
+          show: 'available',
+          status: 'Not Hanging out',
+          priority: ""
+        }
+      };
+      expect(contact.getStatus()).to.eql('available');
+    });
+
     bdd.describe('aggregate status', function () {
       bdd.describe('when there are no online resources', function () {
         bdd.it('is unavailable when there are no online resources', function () {


### PR DESCRIPTION
Per http://xmpp.org/rfcs/rfc3921.html#rfc.section.2.2.2.3
“If no priority is provided, a server SHOULD consider the priority to be zero.”