### PR TITLE
#473: Error message processing

### DIFF
--- a/src/core/event.js
+++ b/src/core/event.js
@@ -774,11 +774,16 @@ Candy.Core.Event = (function(self, Strophe, $) {
 					message = { from: from, name: Strophe.getNodeFromJid(from), body: msg.children('subject').text(), type: 'subject' };
 				// Error messsage
 				} else if(msg.attr('type') === 'error') {
-					var error = msg.children('error');
-					if(error.children('text').length > 0) {
-						roomJid = partnerJid;
-						roomName = Strophe.getNodeFromJid(roomJid);
-						message = { from: msg.attr('from'), type: 'info', body: error.children('text').text() };
+					var error = msg.children("error");
+					roomJid = partnerJid;
+					roomName = Strophe.getNodeFromJid(roomJid);
+					message = {
+						from: msg.attr("from"),
+						name: "error",
+						body: error.children()[0].nodeName
+					};
+					if (error.text().trim().length > 0) {
+						message.body = error.children('text').text();
 					}
 				// Chat message
 				} else if(msg.children('body').length > 0) {


### PR DESCRIPTION
This is a fix for #473 (further context in https://groups.google.com/forum/#!topic/candy-chat/plwovsjyx38 )

Displaying an error message should not depend on the XMPP error to contain a text element (as such element is optional).

This modification removes the 'info' type from the message that is displayed, to prevent XHTML processing problems. There might be cleaner fix for this, but that's beyond my javascript foo.

I'm wondering if this bit of the code behaves differently, when executed in the context of regular rooms, versus one-on-one/private chats. I've tested with the latter (using the muc#roomconfig_allowpm chatroom configuration option).