### PR TITLE
Prevent XHTML parsing when XHTML is not enabled.

### DIFF
--- a/src/core/event.js
+++ b/src/core/event.js
@@ -852,10 +852,12 @@ Candy.Core.Event = (function(self, Strophe, $) {
 						}
 					}
 
-					var xhtmlChild = msg.children('html[xmlns="' + Strophe.NS.XHTML_IM + '"]');
-					if(xhtmlChild.length > 0) {
-						var xhtmlMessage = $($('<div>').append(xhtmlChild.children('body').first().contents()).html());
-						message.xhtmlMessage = xhtmlMessage;
+					if ( Candy.View.getOptions().enableXHTML === true ) {
+						var xhtmlChild = msg.children('html[xmlns="' + Strophe.NS.XHTML_IM + '"]');
+						if(xhtmlChild.length > 0) {
+							var xhtmlMessage = $($('<div>').append(xhtmlChild.children('body').first().contents()).html());
+							message.xhtmlMessage = xhtmlMessage;
+						}
 					}
 
 					self.Jabber.Room._checkForChatStateNotification(msg, roomJid, name);


### PR DESCRIPTION
When XHTML is not explicitly enabled, there's no point in parsing the XHTML content of a message.

Note that this change prevents an XHTML-parsing bug that disconnects the user from occurring when XHTML parsing is not enabled.