### PR TITLE
Fixed double parsing of Candy-generated messages as XHTML

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -112,7 +112,7 @@ Candy.Util = (function(self, $){
     self.parseAndCropXhtml = function(str, len) {
         var msg = str;
         if ( typeof str !== 'string' ) {
-            msg = self.createHtml($(str).get(0), len)
+            msg = self.createHtml($(str).get(0), len);
         }
         return $("<div/>").append(msg).html();
     };

--- a/src/util.js
+++ b/src/util.js
@@ -109,13 +109,13 @@ Candy.Util = (function(self, $){
 	 *   (String) str - String containing XHTML
 	 *   (Integer) len - Max text length
 	 */
-    self.parseAndCropXhtml = function(str, len) {
-        var msg = str;
-        if ( typeof str !== 'string' ) {
-            msg = self.createHtml($(str).get(0), len);
-        }
-        return $("<div/>").append(msg).html();
-    };
+	self.parseAndCropXhtml = function(str, len) {
+		var msg = str;
+		if ( typeof str !== 'string' ) {
+			msg = self.createHtml($(str).get(0), len);
+		}
+		return $("<div/>").append(msg).html();
+	};
 	/** Function: setCookie
 	 * Sets a new cookie
 	 *

--- a/src/util.js
+++ b/src/util.js
@@ -116,6 +116,7 @@ Candy.Util = (function(self, $){
 		}
 		return $("<div/>").append(msg).html();
 	};
+
 	/** Function: setCookie
 	 * Sets a new cookie
 	 *

--- a/src/util.js
+++ b/src/util.js
@@ -109,10 +109,13 @@ Candy.Util = (function(self, $){
 	 *   (String) str - String containing XHTML
 	 *   (Integer) len - Max text length
 	 */
-	self.parseAndCropXhtml = function(str, len) {
-		return $('<div/>').append(self.createHtml($(str).get(0), len)).html();
-	};
-
+    self.parseAndCropXhtml = function(str, len) {
+        var msg = str;
+        if ( typeof str !== 'string' ) {
+            msg = self.createHtml($(str).get(0), len)
+        }
+        return $("<div/>").append(msg).html();
+    };
 	/** Function: setCookie
 	 * Sets a new cookie
 	 *


### PR DESCRIPTION
parseAndCropXHTML() currently parses already parsed XHTML messages and this causes an error.